### PR TITLE
Fixing segmentation fault on password entry

### DIFF
--- a/slock.c
+++ b/slock.c
@@ -18,6 +18,7 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <Imlib2.h>
+#include <crypt.h>
 
 #if HAVE_BSD_AUTH
 #include <login_cap.h>


### PR DESCRIPTION
Without the crypt header, the `running = !!strcmp(crypt(passwd, pws), pws);` line is misinterpreted by GCC.

Fix found from https://github.com/kuravih/gllock/pull/5.